### PR TITLE
Add rust to popular lang list

### DIFF
--- a/Sources/GitHubTrendingRSSKit/Const.swift
+++ b/Sources/GitHubTrendingRSSKit/Const.swift
@@ -64,6 +64,7 @@ public class Const {
         "python",
         "r",
         "ruby",
+        "rust",
         "scala",
         "shell",
         "swift",


### PR DESCRIPTION
## Description
This pull request adds Rust to the list of popular programming languages. As of 2023, [Rust has been ranked #18 in the top 20](https://www.tiobe.com/tiobe-index/) most popular programming languages, making it a valuable addition to the list.

## Changes Made
- Added Rust to the list of popular programming languages.

## Why this change is important
Rust is a fast, safe, and concurrent programming language that is widely used for system programming, game development, and web assembly. With its growing popularity and adoption, it is important to include Rust in the list of popular programming languages to provide a comprehensive overview of the current programming landscape.

## Additional context
N/A
