### PR TITLE
Add English-only feeds by checking spoken_language

### DIFF
--- a/Sources/GitHubTrendingRSS/main.swift
+++ b/Sources/GitHubTrendingRSS/main.swift
@@ -59,56 +59,80 @@ func start() async throws {
         throw MainError.noLanguageTrendingLinks
     }
 
-    for period in Period.allCases {
-        let chunkedLinks = languageLinks.chunked(into: parallelDownloadChunk)
-        
-        for chunk in chunkedLinks {
-            await withTaskGroup(of: Void.self) { group in
-                for link in chunk {
-                    group.addTask {
-                        do {
-                            let repositories = try await gitHubDownloader.fetchRepositories(
-                                ofLink: link,
+    for spokenLanguage in SpokenLanguage.allCases {
+        for period in Period.allCases {
+            let chunkedLinks = languageLinks.chunked(into: parallelDownloadChunk)
+            
+            for chunk in chunkedLinks {
+                await withTaskGroup(of: Void.self) { group in
+                    for link in chunk {
+                        group.addTask {
+                            await processFeed(
+                                link: link,
                                 period: period,
-                                includesReadMeIfExists: Const.popularLanguages.contains(link.name)
+                                spokenLanguage: spokenLanguage,
+                                supportedEmojis: supportedEmojis,
+                                gitHubDownloader: gitHubDownloader,
+                                graphQLManager: graphQLManager,
+                                feedManager: feedManager
                             )
-                            
-                            var updatedRepositories = repositories
-                            if !repositories.isEmpty {
-                                let reposQueryInfo = repositories.map { (owner: $0.pageLink.userID, name: $0.pageLink.repositoryName) }
-                                
-                                do {
-                                    let ogDataMap = try await graphQLManager.fetchRepositoriesOGImages(repositories: reposQueryInfo)
-                                    for i in 0..<updatedRepositories.count {
-                                        if let ogNode = ogDataMap["repo_\(i)"] {
-                                            updatedRepositories[i].openGraphImageUrl = ogNode.openGraphImageUrl
-                                            updatedRepositories[i].usesCustomOpenGraphImage = ogNode.usesCustomOpenGraphImage
-                                        }
-                                    }
-                                } catch {
-                                    NSLog("⚠️ Failed to fetch GraphQL for \(link.name): \(error). Proceeding without OG Images.")
-                                }
-                            }
-                            
-                            try await feedManager.createRSSFile(
-                                repositories: updatedRepositories,
-                                languageTrendingLink: link,
-                                period: period,
-                                supportedEmojis: supportedEmojis
-                            )
-                        } catch {
-                            if let error = error as? DownloadManager.Error,
-                               error == .failedFetching(statusCode: 504) || error == .failedFetching(statusCode: 502) {
-                                // ignore
-                            } else {
-                                NSLog("⚠️ Failed to fetch repositories of \(link.name). Error: \(error)")
-                            }
                         }
                     }
                 }
             }
+        }
+    }
+    
+    _ = try? feedManager.createRSSListFile(languageLinks: languageLinks)
+}
+
+private func processFeed(
+    link: LanguageTrendingLink,
+    period: Period,
+    spokenLanguage: SpokenLanguage,
+    supportedEmojis: [GitHubEmoji],
+    gitHubDownloader: GitHubDownloader,
+    graphQLManager: GitHubGraphQLManager,
+    feedManager: FeedFileCreator
+) async {
+    do {
+        let repositories = try await gitHubDownloader.fetchRepositories(
+            ofLink: link,
+            period: period,
+            spokenLanguage: spokenLanguage,
+            includesReadMeIfExists: Const.popularLanguages.contains(link.name)
+        )
+        
+        var updatedRepositories = repositories
+        if !repositories.isEmpty {
+            let reposQueryInfo = repositories.map { (owner: $0.pageLink.userID, name: $0.pageLink.repositoryName) }
             
-            _ = try? feedManager.createRSSListFile(languageLinks: languageLinks)
+            do {
+                let ogDataMap = try await graphQLManager.fetchRepositoriesOGImages(repositories: reposQueryInfo)
+                for i in 0..<updatedRepositories.count {
+                    if let ogNode = ogDataMap["repo_\(i)"] {
+                        updatedRepositories[i].openGraphImageUrl = ogNode.openGraphImageUrl
+                        updatedRepositories[i].usesCustomOpenGraphImage = ogNode.usesCustomOpenGraphImage
+                    }
+                }
+            } catch {
+                NSLog("⚠️ Failed to fetch GraphQL for \(link.name): \(error). Proceeding without OG Images.")
+            }
+        }
+        
+        try await feedManager.createRSSFile(
+            repositories: updatedRepositories,
+            languageTrendingLink: link,
+            period: period,
+            spokenLanguage: spokenLanguage,
+            supportedEmojis: supportedEmojis
+        )
+    } catch {
+        if let error = error as? DownloadManager.Error,
+           error == .failedFetching(statusCode: 504) || error == .failedFetching(statusCode: 502) {
+            // ignore
+        } else {
+            NSLog("⚠️ Failed to fetch repositories of \(link.name) (\(spokenLanguage.rawValue)). Error: \(error)")
         }
     }
 }

--- a/Sources/GitHubTrendingRSSKit/Managers/FeedFileCreator.swift
+++ b/Sources/GitHubTrendingRSSKit/Managers/FeedFileCreator.swift
@@ -11,16 +11,17 @@ public final class FeedFileCreator: @unchecked Sendable {
         rootOutputDirectory = outputDirectory
     }
 
-    @discardableResult public func createRSSFile(repositories: [Repository], languageTrendingLink: LanguageTrendingLink, period: Period, supportedEmojis: [GitHubEmoji]) async throws -> URL {
+    @discardableResult public func createRSSFile(repositories: [Repository], languageTrendingLink: LanguageTrendingLink, period: Period, spokenLanguage: SpokenLanguage, supportedEmojis: [GitHubEmoji]) async throws -> URL {
         let fileManager = FileManager.default
         let feedHTML = try await siteGenerator.makeRSS(
             from: languageTrendingLink,
             period: period,
+            spokenLanguage: spokenLanguage,
             repositories: repositories,
             supportedEmojis: supportedEmojis
         )
 
-        let outputDirectory = rootOutputDirectory.appendingPathComponent(period.rawValue)
+        let outputDirectory = spokenLanguage.outputDirectory(relativeTo: rootOutputDirectory, period: period)
 
         try fileManager.createDirectory(
             at: outputDirectory,

--- a/Sources/GitHubTrendingRSSKit/Managers/GitHubDownloader.swift
+++ b/Sources/GitHubTrendingRSSKit/Managers/GitHubDownloader.swift
@@ -19,9 +19,9 @@ public final class GitHubDownloader: Sendable {
         self.githubToken = githubToken
     }
 
-    public func fetchRepositories(ofLink languageTrendingLink: LanguageTrendingLink, period: Period, includesReadMeIfExists: Bool) async throws -> [Repository] {
+    public func fetchRepositories(ofLink languageTrendingLink: LanguageTrendingLink, period: Period, spokenLanguage: SpokenLanguage = .unspecified, includesReadMeIfExists: Bool) async throws -> [Repository] {
         let page = try await downloadManager.fetch(
-            url: languageTrendingLink.url(ofPeriod: period),
+            url: languageTrendingLink.url(ofPeriod: period, spokenLanguage: spokenLanguage),
             bearerToken: githubToken
         )
         

--- a/Sources/GitHubTrendingRSSKit/Managers/SiteSourceMaker.swift
+++ b/Sources/GitHubTrendingRSSKit/Managers/SiteSourceMaker.swift
@@ -53,7 +53,7 @@ public final class SiteSourceMaker: @unchecked Sendable {
         )
     }
 
-    public func makeRSS(from languageTrendingLink: LanguageTrendingLink, period: Period, repositories: [Repository], supportedEmojis: [GitHubEmoji]) async throws -> String {
+    public func makeRSS(from languageTrendingLink: LanguageTrendingLink, period: Period, spokenLanguage: SpokenLanguage = .unspecified, repositories: [Repository], supportedEmojis: [GitHubEmoji]) async throws -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "E, dd MMM YYYY HH:mm:ss 'GMT'"
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
@@ -76,6 +76,7 @@ public final class SiteSourceMaker: @unchecked Sendable {
 
         let context: [String: Any] = [
             "languageTrendingLink": languageTrendingLink,
+            "spokenLanguage": spokenLanguage,
             "information": information,
             "periodText": period.rawValue.capitalized,
             "pubDate": pubDate,

--- a/Sources/GitHubTrendingRSSKit/Models/PageLinkable.swift
+++ b/Sources/GitHubTrendingRSSKit/Models/PageLinkable.swift
@@ -7,7 +7,7 @@ public protocol PageLinkable: Hashable {
 }
 
 public extension PageLinkable {
-    func url(ofPeriod period: Period) -> URL {
+    func url(ofPeriod period: Period, spokenLanguage: SpokenLanguage = .unspecified) -> URL {
         let path = URL(string: href)!.path
 
         var components = URLComponents(
@@ -16,9 +16,13 @@ public extension PageLinkable {
         )!
 
         components.path = path
-        components.queryItems = [
+        var queryItems = [
             URLQueryItem(name: "since", value: period.rawValue),
         ]
+        if let code = spokenLanguage.code {
+            queryItems.append(URLQueryItem(name: "spoken_language_code", value: code))
+        }
+        components.queryItems = queryItems
 
         return components.url!
     }

--- a/Sources/GitHubTrendingRSSKit/Models/SpokenLanguage.swift
+++ b/Sources/GitHubTrendingRSSKit/Models/SpokenLanguage.swift
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Manabu Nakazawa. Licensed under the MIT license. See LICENSE in the project root for license information.
+
+import Foundation
+
+public enum SpokenLanguage: String, CaseIterable, Sendable {
+    case unspecified
+    case en
+
+    public var code: String? {
+        self == .unspecified ? nil : rawValue
+    }
+
+    public var urlPathPrefix: String {
+        self == .unspecified ? "" : rawValue
+    }
+
+    public var displayName: String {
+        switch self {
+        case .unspecified:
+            "All Spoken Languages"
+        case .en:
+            "English"
+        }
+    }
+
+    public func outputDirectory(relativeTo baseURL: URL, period: Period) -> URL {
+        if urlPathPrefix.isEmpty {
+            return baseURL.appendingPathComponent(period.rawValue)
+        } else {
+            return baseURL.appendingPathComponent(urlPathPrefix).appendingPathComponent(period.rawValue)
+        }
+    }
+}

--- a/Tests/GitHubTrendingRSSTests/FeedFileCreatorTests.swift
+++ b/Tests/GitHubTrendingRSSTests/FeedFileCreatorTests.swift
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Manabu Nakazawa. Licensed under the MIT license. See LICENSE in the project root for license information.
+
+import GitHubTrendingRSSKit
+import PathKit
+import Stencil
+import XCTest
+
+final class FeedFileCreatorTests: XCTestCase {
+    private let environment = Environment(loader: FileSystemLoader(paths: [Path(Const.resourcesRootURL.path)]))
+    private let information = SiteSourceMaker.Information(
+        pageTitle: "page title",
+        author: "spring water",
+        rssHomeURL: "rss home url",
+        googleAnalyticsTrackingCode: "141421356",
+        gitHubRepositoryURL: "github repository url"
+    )
+    private var tempDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await DocslothManager.shared.setup()
+        tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        try await super.tearDown()
+    }
+
+    func testCreateRSSFilePaths() async throws {
+        let maker = SiteSourceMaker(environment: environment, information: information)
+        let creator = FeedFileCreator(outputDirectory: tempDir, siteGenerator: maker)
+        let link = LanguageTrendingLink(displayName: "All Languages", href: Const.gitHubTopTrendingURL.path)
+
+        let urlUnspecified = try await creator.createRSSFile(
+            repositories: [],
+            languageTrendingLink: link,
+            period: .daily,
+            spokenLanguage: .unspecified,
+            supportedEmojis: []
+        )
+        XCTAssertEqual(urlUnspecified.path, tempDir.appendingPathComponent("daily/all.xml").path)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: urlUnspecified.path))
+
+        let urlEn = try await creator.createRSSFile(
+            repositories: [],
+            languageTrendingLink: link,
+            period: .daily,
+            spokenLanguage: .en,
+            supportedEmojis: []
+        )
+        XCTAssertEqual(urlEn.path, tempDir.appendingPathComponent("en/daily/all.xml").path)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: urlEn.path))
+    }
+}

--- a/Tests/GitHubTrendingRSSTests/ModelsTests.swift
+++ b/Tests/GitHubTrendingRSSTests/ModelsTests.swift
@@ -138,4 +138,24 @@ final class ModelsTests: XCTestCase {
         let html = try XCTUnwrap(readMeHTML)
         XCTAssertTrue(html.contains(#""https://raw.githubusercontent.com/user/repo/master/hello.svg""#))
     }
+
+    func testPageLinkableURLWithSpokenLanguage() {
+        let link = LanguageTrendingLink(displayName: "Swift", href: "/swift")
+
+        let unspecifiedURL = link.url(ofPeriod: .daily, spokenLanguage: .unspecified)
+        XCTAssertEqual(unspecifiedURL.absoluteString, "https://github.com/swift?since=daily")
+
+        let enURL = link.url(ofPeriod: .daily, spokenLanguage: .en)
+        XCTAssertEqual(enURL.absoluteString, "https://github.com/swift?since=daily&spoken_language_code=en")
+    }
+
+    func testSpokenLanguageOutputDirectory() {
+        let baseURL = URL(fileURLWithPath: "/tmp/output")
+
+        let unspecifiedDir = SpokenLanguage.unspecified.outputDirectory(relativeTo: baseURL, period: .daily)
+        XCTAssertEqual(unspecifiedDir.path, "/tmp/output/daily")
+
+        let enDir = SpokenLanguage.en.outputDirectory(relativeTo: baseURL, period: .weekly)
+        XCTAssertEqual(enDir.path, "/tmp/output/en/weekly")
+    }
 }

--- a/Tests/GitHubTrendingRSSTests/SiteGeneratorTests.swift
+++ b/Tests/GitHubTrendingRSSTests/SiteGeneratorTests.swift
@@ -54,4 +54,17 @@ final class SiteGeneratorTests: XCTestCase {
         XCTAssertTrue(html.contains("hello-world.png"))
         XCTAssertTrue(html.contains("<media:content url=\"https://example.com/hello-world.png\" medium=\"image\" />"))
     }
+
+    func testGenerateRSSWithSpokenLanguage() async throws {
+        let html = try await maker.makeRSS(
+            from: LanguageTrendingLink(displayName: "Swift", href: "/swift"),
+            period: .daily,
+            spokenLanguage: .en,
+            repositories: [
+                Repository(pageLink: RepositoryPageLink(href: "foo/bar"), summary: "foo bar"),
+            ],
+            supportedEmojis: supportedEmojis
+        )
+        XCTAssertFalse(html.isEmpty)
+    }
 }


### PR DESCRIPTION
The first PR for #20.

For now, I’ve only added an English filter. Chinese users may also want Chinese-only feeds, but I’ve left that out for now because I’d like to be cautious about adding new filtered feeds, as each one would double the build time.

I haven’t updated the website yet.